### PR TITLE
Better support for namespaces

### DIFF
--- a/anom/__init__.py
+++ b/anom/__init__.py
@@ -2,6 +2,7 @@
 from . import conditions, properties, properties as props
 from .adapter import Adapter, get_adapter, set_adapter
 from .model import Key, Model, Property, delete_multi, get_multi, put_multi, lookup_model_by_kind
+from .namespaces import get_namespace, namespace, set_default_namespace, set_namespace
 from .query import Query, Resultset, Page, Pages
 from .transaction import Transaction, TransactionError, RetriesExceeded, transactional
 

--- a/anom/adapters/datastore_adapter.py
+++ b/anom/adapters/datastore_adapter.py
@@ -149,7 +149,6 @@ class DatastoreAdapter(Adapter):
                 request_keys.remove(key)
 
         results = [None] * len(keys)
-        print(datastore_keys)
         for entity in found:
             index = datastore_keys.index(entity.key)
             results[index] = self._prepare_to_load(entity)

--- a/anom/adapters/datastore_adapter.py
+++ b/anom/adapters/datastore_adapter.py
@@ -230,10 +230,7 @@ class DatastoreAdapter(Adapter):
             yield prop, op, value
 
     def _convert_key_to_datastore(self, anom_key):
-        namespace = anom_key.namespace
-        if anom_key.namespace == "":
-            namespace = None
-        return self.client.key(*anom_key.path, namespace=namespace)
+        return self.client.key(*anom_key.path, namespace=anom_key.namespace or None)
 
     @staticmethod
     def _convert_key_from_datastore(datastore_key):

--- a/anom/adapters/memcache_adapter.py
+++ b/anom/adapters/memcache_adapter.py
@@ -55,7 +55,7 @@ class MemcacheAdapter(Adapter):
       client(pylibmc.Client): The memcached client instance to use.
         This is automatically wrapped inside a ThreadMappedPool.
       adapter(Adapter): The adapter to wrap.
-      namespace(str, optional): The string keys should be prefixed
+      prefix(str, optional): The string keys should be prefixed
         with.  Defaults to ``anom``.
     """
 
@@ -65,10 +65,10 @@ class MemcacheAdapter(Adapter):
     _lock_timeout = 60  # seconds
     _item_timeout = 86400  # one day in seconds
 
-    def __init__(self, client, adapter, *, namespace="anom"):
+    def __init__(self, client, adapter, *, prefix="anom"):
         self.client_pool = pylibmc.ThreadMappedPool(client)
         self.adapter = adapter
-        self.namespace = namespace
+        self.prefix = prefix
 
         self.query = self.adapter.query
 
@@ -167,7 +167,7 @@ class MemcacheAdapter(Adapter):
 
     def _convert_key_to_memcache(self, anom_key):
         digest = md5(str(anom_key).encode("utf-8")).hexdigest()
-        return f"{self.namespace}:{digest}"
+        return f"{self.prefix}:{digest}"
 
     @contextmanager
     def _bust(self, keys):

--- a/anom/model.py
+++ b/anom/model.py
@@ -52,11 +52,11 @@ class Key(KeyLike, namedtuple("Key", ("kind", "id_or_name", "parent", "namespace
         if isinstance(kind, model):
             kind = kind._kind
 
-        if namespace is None:
-            namespace = get_namespace()
-
         if parent and parent.is_partial:
             raise ValueError("Cannot use partial Keys as parents.")
+
+        if namespace is None:
+            namespace = get_namespace()
 
         return super().__new__(cls, kind, id_or_name, parent, namespace)
 

--- a/anom/model.py
+++ b/anom/model.py
@@ -56,11 +56,9 @@ class Key(KeyLike, namedtuple("Key", ("kind", "id_or_name", "parent", "namespace
             raise ValueError("Cannot use partial Keys as parents.")
 
         if parent:
-            if namespace is not None:
-                if namespace != parent.namespace:
-                    raise ValueError(f"Namespace {namespace!r} is different from parent namespace {parent.namespace!r}")
-            else:
-                namespace = parent.namespace
+            if namespace is not None and namespace != parent.namespace:
+                raise ValueError(f"Namespace {namespace!r} is different from parent namespace {parent.namespace!r}.")
+            namespace = parent.namespace
         elif namespace is None:
             namespace = get_namespace()
 

--- a/anom/model.py
+++ b/anom/model.py
@@ -55,7 +55,13 @@ class Key(KeyLike, namedtuple("Key", ("kind", "id_or_name", "parent", "namespace
         if parent and parent.is_partial:
             raise ValueError("Cannot use partial Keys as parents.")
 
-        if namespace is None:
+        if parent:
+            if namespace is not None:
+                if namespace != parent.namespace:
+                    raise ValueError(f"Namespace {namespace!r} is different from parent namespace {parent.namespace!r}")
+            else:
+                namespace = parent.namespace
+        elif namespace is None:
             namespace = get_namespace()
 
         return super().__new__(cls, kind, id_or_name, parent, namespace)

--- a/anom/model.py
+++ b/anom/model.py
@@ -3,6 +3,7 @@ from threading import RLock
 from weakref import WeakValueDictionary
 
 from .adapter import PutRequest, get_adapter
+from .namespaces import get_namespace
 from .query import PropertyFilter, Query
 
 #: The set of known models.  This is used to look up model classes at
@@ -50,6 +51,9 @@ class Key(KeyLike, namedtuple("Key", ("kind", "id_or_name", "parent", "namespace
     def __new__(cls, kind, id_or_name=None, parent=None, namespace=None):
         if isinstance(kind, model):
             kind = kind._kind
+
+        if namespace is None:
+            namespace = get_namespace()
 
         if parent and parent.is_partial:
             raise ValueError("Cannot use partial Keys as parents.")

--- a/anom/namespaces.py
+++ b/anom/namespaces.py
@@ -1,0 +1,68 @@
+from contextlib import contextmanager
+from threading import local
+
+_default_namespace = ""
+_namespace = local()
+_namespace.current = _default_namespace
+
+
+def set_default_namespace(namespace=None):
+    """Set the global default namespace (and the thread-local default).
+
+    Parameters:
+      namespace(str): The namespace to set as the global default.
+
+    Returns:
+      str: The input namespace
+    """
+    if namespace is None:
+        namespace = ""
+    global _default_namespace
+    _namespace.current = _default_namespace = namespace
+    return _default_namespace
+
+
+def get_namespace():
+    """Get the current thread-local default namespace.
+
+    Returns:
+      str: The current thread-local default namespace.
+    """
+    if not hasattr(_namespace, "current"):
+        global _default_namespace
+        _namespace.current = _default_namespace
+    return _namespace.current
+
+
+def set_namespace(namespace=None):
+    """Set the current thread-local default namespace.
+
+    Parameters:
+      namespace(str): namespace to set as the current thread-local default.
+
+    Returns:
+      None
+    """
+    if namespace is None:
+        global _default_namespace
+        namespace = _default_namespace
+    _namespace.current = namespace
+
+
+@contextmanager
+def namespace(namespace):
+    """Context manager for setting the current thread-local default namespace.
+    Exiting the context sets the thread-local default namespace back to the
+    global default namespace.
+
+    Parameters:
+      namespace(str): namespace to set as the current thread-local default.
+
+    Returns:
+      None
+    """
+    set_namespace(namespace)
+    try:
+        yield
+    finally:
+        set_namespace(None)

--- a/anom/namespaces.py
+++ b/anom/namespaces.py
@@ -28,10 +28,12 @@ def get_namespace():
     Returns:
       str: The current thread-local default namespace.
     """
-    if not hasattr(_namespace, "current"):
+    try:
+        return _namespace.current
+    except AttributeError:
         global _default_namespace
         _namespace.current = _default_namespace
-    return _namespace.current
+        return _namespace.current
 
 
 def set_namespace(namespace=None):

--- a/anom/namespaces.py
+++ b/anom/namespaces.py
@@ -29,7 +29,6 @@ def get_namespace():
     try:
         return _namespace.current
     except AttributeError:
-        global _default_namespace
         _namespace.current = _default_namespace
         return _namespace.current
 
@@ -44,7 +43,6 @@ def set_namespace(namespace=None):
       None
     """
     if namespace is None:
-        global _default_namespace
         namespace = _default_namespace
     _namespace.current = namespace
 

--- a/anom/namespaces.py
+++ b/anom/namespaces.py
@@ -15,10 +15,8 @@ def set_default_namespace(namespace=None):
     Returns:
       str: The input namespace
     """
-    if namespace is None:
-        namespace = ""
     global _default_namespace
-    _namespace.current = _default_namespace = namespace
+    _namespace.current = _default_namespace = namespace or ""
     return _default_namespace
 
 

--- a/anom/query.py
+++ b/anom/query.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from .namespaces import get_namespace
 
 
 class PropertyFilter(namedtuple("PropertyFilter", ("name", "operator", "value"))):
@@ -261,7 +262,7 @@ class Query(namedtuple("Query", (
             cls, kind=None, *, ancestor=None, namespace=None,
             projection=(), filters=(), orders=(), offset=0, limit=None,
     ):
-        from .model import lookup_model_by_kind
+        from .model import get_adapter, lookup_model_by_kind
 
         if kind is None:
             model = None
@@ -271,6 +272,9 @@ class Query(namedtuple("Query", (
 
         else:
             model, kind = kind, kind._kind
+
+        if namespace is None:
+            namespace = get_namespace()
 
         return super().__new__(
             cls, model=model, kind=kind, ancestor=ancestor, namespace=namespace,

--- a/anom/query.py
+++ b/anom/query.py
@@ -262,7 +262,7 @@ class Query(namedtuple("Query", (
             cls, kind=None, *, ancestor=None, namespace=None,
             projection=(), filters=(), orders=(), offset=0, limit=None,
     ):
-        from .model import get_adapter, lookup_model_by_kind
+        from .model import lookup_model_by_kind
 
         if kind is None:
             model = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@ import logging
 import pylibmc
 import pytest
 
-from anom import Adapter, Key, Query, adapters, get_adapter, set_adapter, delete_multi
+from anom import Adapter, Key, Query, adapters, get_adapter, set_adapter, put_multi, delete_multi, set_default_namespace
 from anom.testing import Emulator
+from concurrent import futures
 
 from .models import Person, Mutant, Cat, Human, Eagle
 
@@ -33,30 +34,34 @@ def noop_adapter():
     set_adapter(old_adapter)
 
 
-@pytest.fixture(params=["datastore", "memcache"])
-def adapter(request, emulator, memcache_client):
-    old_adapter = get_adapter()
-    ds_adapter = adapters.DatastoreAdapter()
+@pytest.fixture(params=[None, "namespace"])
+def default_namespace(request):
+    yield set_default_namespace(request.param)
+    set_default_namespace(None)
 
-    if request.param == "datastore":
-        adapter = ds_adapter
-    elif request.param == "memcache":
-        adapter = adapters.MemcacheAdapter(memcache_client, ds_adapter)
 
+@pytest.fixture
+def datastore_adapter(emulator, default_namespace):
+    adapter = adapters.DatastoreAdapter()
     adapter = set_adapter(adapter)
     yield adapter
-
     all_entities = list(Query().run(keys_only=True))
     delete_multi(all_entities)
-    set_adapter(old_adapter)
+    set_adapter(None)
 
 
 @pytest.fixture()
-def memcache_adapter(emulator, memcache_client):
-    old_adapter = get_adapter()
-    adapter = set_adapter(adapters.MemcacheAdapter(memcache_client, adapters.DatastoreAdapter()))
+def memcache_adapter(datastore_adapter, memcache_client):
+    adapter = set_adapter(
+        adapters.MemcacheAdapter(memcache_client, datastore_adapter)
+    )
     yield adapter
-    set_adapter(old_adapter)
+    set_adapter(None)
+
+
+@pytest.fixture(params=["datastore_adapter", "memcache_adapter"])
+def adapter(request):
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture()
@@ -91,19 +96,19 @@ def person_with_ancestor(person):
         first_name="Child",
         last_name="Person",
     )
-    child.key = Key(Person, parent=person.key)
+    child.key = Key(Person, parent=person.key, namespace=person.key.namespace)
     child.put()
     yield child
     child.delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def people(adapter):
-    people = []
-    for i in range(1, 21):
-        person = Person(email=f"{i}@example.com", first_name="Person", last_name=str(i))
-        person.key = Key(Person, i)
-        people.append(person.put())
+    people = put_multi([
+        Person(
+            key=Key(Person, i), email=f"{i}@example.com", first_name="Person", last_name=str(i)
+        ) for i in range(1, 21)
+    ])
 
     yield people
 
@@ -138,3 +143,9 @@ def eagle(adapter):
     eagle = Eagle().put()
     yield eagle
     eagle.delete()
+
+
+@pytest.fixture
+def executor():
+    with futures.ThreadPoolExecutor() as executor:
+        yield executor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,12 +36,13 @@ def noop_adapter():
 
 @pytest.fixture(params=[None, "namespace"])
 def default_namespace(request):
-    yield set_default_namespace(request.param)
+    namespace = getattr(request, "param", None)
+    yield set_default_namespace(namespace)
     set_default_namespace(None)
 
 
 @pytest.fixture
-def datastore_adapter(emulator, default_namespace):
+def datastore_adapter(emulator):
     adapter = adapters.DatastoreAdapter()
     adapter = set_adapter(adapter)
     yield adapter
@@ -60,7 +61,7 @@ def memcache_adapter(datastore_adapter, memcache_client):
 
 
 @pytest.fixture(params=["datastore_adapter", "memcache_adapter"])
-def adapter(request):
+def adapter(request, default_namespace):
     return request.getfixturevalue(request.param)
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -50,7 +50,7 @@ def test_keys_can_fail_to_lookup_models_by_kind():
 
 
 def test_keys_reprs_can_be_used_to_rebuild_them():
-    assert repr(Key("Foo", 123)) == "Key('Foo', 123, parent=None, namespace=None)"
+    assert repr(Key("Foo", 123)) == "Key('Foo', 123, parent=None, namespace='')"
 
 
 def test_keys_can_be_equal():

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -30,6 +30,12 @@ def test_keys_parents_must_not_be_partial():
         Key("Person", 123, parent=Key("Organization"))
 
 
+def test_keys_namespace_Must_match_parent_namespace():
+    parent = Key("Organization", 123, namespace="a")
+    with pytest.raises(ValueError):
+        Key("Person", 123, parent=parent, namespace="b")
+
+
 def test_keys_can_have_numeric_ids():
     assert Key("Person", 123).int_id == 123
     assert Key("Person", 123).str_id is None

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -30,7 +30,12 @@ def test_keys_parents_must_not_be_partial():
         Key("Person", 123, parent=Key("Organization"))
 
 
-def test_keys_namespace_Must_match_parent_namespace():
+def test_key_inherits_parents_namespace():
+    parent = Key("Organization", 123, namespace="a")
+    assert Key("Person", 123, parent=parent).namespace == parent.namespace
+
+
+def test_keys_namespace_must_match_parent_namespace():
     parent = Key("Organization", 123, namespace="a")
     with pytest.raises(ValueError):
         Key("Person", 123, parent=parent, namespace="b")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -60,7 +60,7 @@ def test_models_cannot_have_overlapping_kinds():
 
 def test_model_reprs_can_be_used_to_rebuild_them():
     assert repr(Person(email="foo@example.com")) == \
-        "Person(key=Key('Person', None, parent=None, namespace=None), em" \
+        "Person(key=Key('Person', None, parent=None, namespace=''), em" \
         "ail='foo@example.com', first_name=None, last_name=None, parent=" \
         "None, created_at=None)"
 
@@ -99,3 +99,8 @@ def test_models_can_have_custom_kinds(adapter):
     assert e.key.kind == "CustomKind"
     assert e.key.get() == e
     assert e.delete() is None
+
+
+def test_default_model_key_uses_default_namespace(adapter, namespace):
+    namespace = namespace or ""
+    assert Person().key.namespace == namespace

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,6 +101,5 @@ def test_models_can_have_custom_kinds(adapter):
     assert e.delete() is None
 
 
-def test_default_model_key_uses_default_namespace(adapter, namespace):
-    namespace = namespace or ""
-    assert Person().key.namespace == namespace
+def test_default_model_key_uses_default_namespace(adapter, default_namespace):
+    assert Person().key.namespace == default_namespace

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -120,10 +120,17 @@ def test_datastore_client_uses_the_default_namespace():
     # Given that I've set a default namespace
     anom.set_default_namespace("anomspace")
 
-    # When I instantiate a DatastoreAdapter
+    # And I have a DatastoreAdapter
     adapter = anom.adapters.DatastoreAdapter()
 
-    # I expect the adapter's client to use that namespace
-    assert adapter.client.namespace == "anomspace"
+    # And the adapter hasn't instantiated a client yet
+    adapter._state.client = None
+
+    # When I get the adapter's client
+    client = adapter.client
+
+    # I expect the client's namespace to match the global default
+    assert client.namespace == "anomspace"
 
     anom.set_default_namespace()
+    adapter._state.client = None

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -1,0 +1,124 @@
+import anom
+
+from . import models  # noqa
+
+
+def test_can_set_default_namespace(executor):
+    # Given that the current namespace is the empty/global namespace
+    assert anom.get_namespace() == ""
+
+    # When I set the global default namespace to "anomspace"
+    anom.set_default_namespace("anomspace")
+
+    # I expect get_namespace to return the new global default
+    assert anom.get_namespace() == "anomspace"
+
+    # And keys without an explicit namespace to use the global default
+    assert anom.Key(models.BankAccount).namespace == "anomspace"
+
+    # And queries without an explicit namespace to use the global default
+    assert models.BankAccount().query().namespace == "anomspace"
+
+    # And for other threads to use the global default
+    assert executor.submit(anom.get_namespace).result() == "anomspace"
+
+
+def test_can_set_namespace(default_namespace, executor):
+    # Given that I have some global default namespace
+    assert anom.get_namespace() == default_namespace
+
+    # And that namespace is not "anomspace"
+    assert default_namespace != "anomspace"
+
+    # When I set the local default namespace to "anomspace"
+    anom.set_namespace("anomspace")
+
+    # I expect get_namespace to return the new local default namespace
+    assert anom.get_namespace() == "anomspace"
+
+    # And keys without an explicit namespace to use the local default
+    assert anom.Key(models.BankAccount).namespace == "anomspace"
+
+    # And queries without an explicit namespace to use the local default
+    assert models.BankAccount().query().namespace == "anomspace"
+
+    # And for other threads to still use the global default
+    assert executor.submit(anom.get_namespace).result() == default_namespace
+
+    # When I set the local default namespace to None
+    anom.set_namespace(None)
+
+    # I expect everything to go back to using the global default
+    assert anom.get_namespace() == default_namespace
+    assert anom.Key(models.BankAccount).namespace == default_namespace
+    assert models.BankAccount().query().namespace == default_namespace
+    assert executor.submit(anom.get_namespace).result() == default_namespace
+
+
+def test_namespace_context_manager(default_namespace, executor):
+    # Given that I have some global default namespace
+    assert anom.get_namespace() == default_namespace
+
+    # And that namespace is not "anomspace"
+    assert default_namespace != "anomspace"
+
+    # When I set the local default namespace with the context manager
+    with anom.namespace("anomspace"):
+        # I expect everything inside the context to use the new local default
+        assert anom.get_namespace() == "anomspace"
+        assert anom.Key(models.BankAccount).namespace == "anomspace"
+        assert models.BankAccount().query().namespace == "anomspace"
+
+        # But other threads should still use the global default
+        assert executor.submit(anom.get_namespace).result() == default_namespace
+
+    # When I exit the context, I expect everything to revert to using the global
+    # default namespace again
+    assert anom.get_namespace() == default_namespace
+    assert anom.Key(models.BankAccount).namespace == default_namespace
+    assert models.BankAccount().query().namespace == default_namespace
+    assert executor.submit(anom.get_namespace).result() == default_namespace
+
+
+def test_namespaces_persist_through_changes_once_set(default_namespace):
+    # Given that I have some global default namespace
+    assert anom.get_namespace() == default_namespace
+
+    # And I have some things that I instantiated with that default namespace
+    key = anom.Key(models.BankAccount)
+    query = models.BankAccount.query()
+
+    # When I change the local default namespace
+    anom.set_namespace("anomspace")
+
+    # I expect all of those things to still use the global default namespace
+    assert key.namespace == default_namespace
+    assert query.namespace == default_namespace
+
+    # Given that I made new things with the new local default namespace
+    key = anom.Key(models.BankAccount)
+    query = models.BankAccount.query()
+
+    # When I change the local default namespace again
+    with anom.namespace("monaspace"):
+        # I expect all of those things to still use the previous local default
+        assert key.namespace == "anomspace"
+        assert query.namespace == "anomspace"
+
+        # Given that I made new things with the new local default namespace
+        key = anom.Key(models.BankAccount)
+        query = models.BankAccount.query()
+
+    # When I exit the context and the local default goes back to the global
+    # default, I expect everything to still use the namespace they were created
+    # with
+    assert key.namespace == "monaspace"
+    assert query.namespace == "monaspace"
+
+
+def test_datastore_client_uses_the_default_namespace(datastore_adapter):
+    # Given that I've set a default namespace
+    anom.set_default_namespace("anomspace")
+
+    # I expect the datastore adapter's client to use that namespace
+    assert datastore_adapter.client.namespace == "anomspace"

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -120,5 +120,14 @@ def test_datastore_client_uses_the_default_namespace():
     # Given that I've set a default namespace
     anom.set_default_namespace("anomspace")
 
-    # I expect the datastore adapter's client to use that namespace
-    assert anom.DatastoreAdapter().client.namespace == "anomspace"
+    # And the datastore client hasn't been instantiated yet
+    anom.adapters.DatastoreAdapter._state.client = None
+
+    # When I instantiate a DatastoreAdapter
+    adapter = anom.adapters.DatastoreAdapter()
+
+    # I expect the adapter's client to use that namespace
+    assert adapter.client.namespace == "anomspace"
+
+    anom.set_default_namespace()
+    anom.adapters.DatastoreAdapter._state.client = None

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -120,9 +120,6 @@ def test_datastore_client_uses_the_default_namespace():
     # Given that I've set a default namespace
     anom.set_default_namespace("anomspace")
 
-    # And the datastore client hasn't been instantiated yet
-    anom.adapters.DatastoreAdapter._state.client = None
-
     # When I instantiate a DatastoreAdapter
     adapter = anom.adapters.DatastoreAdapter()
 
@@ -130,4 +127,3 @@ def test_datastore_client_uses_the_default_namespace():
     assert adapter.client.namespace == "anomspace"
 
     anom.set_default_namespace()
-    anom.adapters.DatastoreAdapter._state.client = None

--- a/tests/test_namespaces.py
+++ b/tests/test_namespaces.py
@@ -116,9 +116,9 @@ def test_namespaces_persist_through_changes_once_set(default_namespace):
     assert query.namespace == "monaspace"
 
 
-def test_datastore_client_uses_the_default_namespace(datastore_adapter):
+def test_datastore_client_uses_the_default_namespace():
     # Given that I've set a default namespace
     anom.set_default_namespace("anomspace")
 
     # I expect the datastore adapter's client to use that namespace
-    assert datastore_adapter.client.namespace == "anomspace"
+    assert anom.DatastoreAdapter().client.namespace == "anomspace"


### PR DESCRIPTION
Trying to use a default namespace by passing it to the `DatastoreAdapter` as a kwarg turns out to be super broken, since almost nothing uses that value. Namespace support in general was fairly incomplete unless you felt like managing it yourself on an object-by-object basis. Things are improved here by:

- Removed the `namespace` kwarg from `DatastoreAdapter`
- Renamed the `namespace` kwarg for `MemcacheAdapter` to `prefix` because that was confusing
- Added the ability to set a global default namespace with `set_default_namespace`
- `Key` and `Query` will now use the current default namespace if they don't have one explicitly defined
- Added `set_namespace` and `get_namespace` functions that work essentially like their Google `namespace_manager` counterparts, with the exception being that `set_namespace` is a thread-local change
- Added a `namespace` context manager to make it simpler to change the namespace temporarily before reverting back to the global default (again, this change is thread-local)