### PR TITLE
fix: validate None with optional indexed String

### DIFF
--- a/anom/properties.py
+++ b/anom/properties.py
@@ -602,6 +602,9 @@ class String(Encodable, Property):
         if not self.indexed:
             return value
 
+        if self.optional and value is None:
+            return value
+
         if not self.repeated:
             self._validate_length(value)
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -165,6 +165,17 @@ def test_optional_properties_can_be_assigned_none():
         assert prop.validate(None) is None
 
 
+def test_optional_indexed_properties_can_be_assigned_none():
+    indexable_properties = [
+        x
+        for _, x in all_properties
+        if not issubclass(x, props.Blob)
+    ]
+    for property_class in indexable_properties:
+        prop = property_class(indexed=True, optional=True)
+        assert prop.validate(None) is None
+
+
 def test_uninitialized_properties_return_none_on_get():
     entity = models.ModelWithInteger()
     assert entity.x is None


### PR DESCRIPTION
When querying on String properties that are optional and indexed, a TypeError is thrown:

```
File "/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/model.py", line 321, in __eq__
    return self._build_filter("=", value)
  File "/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/model.py", line 318, in _build_filter
    return PropertyFilter(self.name_on_entity, op, self.validate(value))
  File "/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/properties.py", line 606, in validate
    self._validate_length(value)
  File "/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/properties.py", line 592, in _validate_length
    if len(value) > _max_indexed_length and \
TypeError: object of type 'NoneType' has no len()
```

Turns out there are no checks in `String.validate` for whether the value is `None`, which should be allowed because the property is marked as optional. After that it tries to validate with `len()` assuming the value is a string, where the TypeError is thrown.

This adds a check in the `validate` method for `String` so it accepts `None` values if it is marked optional, and a test showing it now works.