### PR TITLE
fix: store repeated optional embedded properties

### DIFF
--- a/anom/model.py
+++ b/anom/model.py
@@ -304,6 +304,9 @@ class Property:
             else:
                 return None
 
+        if self.optional and value == []:
+            value = ob._data[self.name_on_model] = None
+
         return value
 
     def __set__(self, ob, value):

--- a/anom/properties.py
+++ b/anom/properties.py
@@ -691,6 +691,9 @@ class Embed(EmbedLike):
         return self._prepare_to_load_properties(data)
 
     def _prepare_to_load_repeated_properties(self, data):
+        if self.optional and not data:
+            return None
+
         datas = [{} for _ in range(len(next(iter(data.values()))))]
         for key, values in data.items():
             for i, value in enumerate(values):
@@ -725,6 +728,8 @@ class Embed(EmbedLike):
 
         # Ensure all sublists are equal, otherwise rebuilding the
         # entity is not going to be possible.
+        import logging
+        logging.warning(f"{properties}")
         props_are_valid = reduce(operator.eq, (len(val) for val in properties.values()))
         if not props_are_valid:  # pragma: no cover
             raise ValueError(

--- a/anom/properties.py
+++ b/anom/properties.py
@@ -721,6 +721,9 @@ class Embed(EmbedLike):
             raise RuntimeError(f"Property {self.name_on_model} requires a value.")
 
     def _prepare_to_store_repeated_properties(self, entities):
+        if self.optional and not entities:
+            return None
+        
         properties = defaultdict(list)
         for entity in entities:
             for name, value in self._prepare_to_store_properties(entity):
@@ -728,8 +731,6 @@ class Embed(EmbedLike):
 
         # Ensure all sublists are equal, otherwise rebuilding the
         # entity is not going to be possible.
-        import logging
-        logging.warning(f"{properties}")
         props_are_valid = reduce(operator.eq, (len(val) for val in properties.values()))
         if not props_are_valid:  # pragma: no cover
             raise ValueError(

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -91,6 +91,33 @@ def test_optional_embedded_properties_can_be_assigned_None(adapter):
     assert outer == outer.key.get()
 
 
+class Point(Model):
+    x = props.Float(indexed=False)
+    y = props.Float(indexed=False)
+
+
+class Place(Model):
+    name = props.String()
+    points = props.Embed(kind=Point, optional=True, repeated=True)
+
+
+def test_optional_repeated_embed_properties_can_be_assigned_none(adapter):
+    # Given that i have an place entity w/ a optional repeated embed property
+    place = Place(
+        name="New York",
+        points=[Point(x=40.7128, y=74.0060)]
+    )
+
+    # When I assign none to that nested property
+    place.points = None
+
+    # And save that entity
+    place.put()
+
+    # Then I should be able to get back the same entity from datastore
+    assert place == place.key.get()
+
+
 class Variation(Model):
     weight = props.Integer(indexed=True)
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -118,6 +118,20 @@ def test_optional_repeated_embed_properties_can_be_assigned_none(adapter):
     assert place == place.key.get()
 
 
+def test_optional_repeated_embed_properties_can_be_created_with_none(adapter):
+    # Given that i have an place entity w/ a optional repeated embed property,
+    # but don't assign it in the constructor
+    place = Place(
+        name="New York"
+    )
+
+    # And save that entity
+    place.put()
+
+    # Then I should be able to get back the same entity from datastore
+    assert place == place.key.get()
+
+
 class Variation(Model):
     weight = props.Integer(indexed=True)
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -131,6 +131,20 @@ def test_optional_repeated_embed_properties_can_be_created_with_none(adapter):
     # Then I should be able to get back the same entity from datastore
     assert place == place.key.get()
 
+def test_optional_repeated_embed_properties_can_be_created_with_empty_list(adapter):
+    # Given that i have an place entity w/ a optional repeated embed property,
+    # but assign it an empty list in the constructor
+    place = Place(
+        name="New York",
+        points=[]
+    )
+
+    # And save that entity with the empty list
+    place.put()
+
+    # Then I should be able to get back the same entity from datastore
+    assert place == place.key.get()
+
 
 class Variation(Model):
     weight = props.Integer(indexed=True)


### PR DESCRIPTION
When storing models with an Embed property that is repeated and optional, the value gets set to an empty list by default (set in [`Property.__get__`](https://github.com/Bogdanp/anom-py/blob/master/anom/model.py#L302)). This causes an error on put:
```
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/model.py:571: in put
    return put_multi([self])[0]
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/model.py:767: in put_multi
    keys = adapter.put_multi(requests)
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/adapters/datastore_adapter.py:149: in put_multi
    entities = [self._prepare_to_store(*request) for request in requests]
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/adapters/datastore_adapter.py:149: in <listcomp>
    entities = [self._prepare_to_store(*request) for request in requests]
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/adapters/datastore_adapter.py:232: in _prepare_to_store
    entity.update({name: self._prepare_to_store_value(value) for name, value in data})
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/adapters/datastore_adapter.py:232: in <dictcomp>
    entity.update({name: self._prepare_to_store_value(value) for name, value in data})
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/model.py:459: in __iter__
    yield from prop.prepare_to_store(self, value)
/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/properties.py:712: in prepare_to_store
    yield from self._prepare_to_store_repeated_properties(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <anom.properties.Embed object at 0x7efea8974c18>, entities = []

    def _prepare_to_store_repeated_properties(self, entities):
        properties = defaultdict(list)
        for entity in entities:
            for name, value in self._prepare_to_store_properties(entity):
                properties[name].append(value)

        # Ensure all sublists are equal, otherwise rebuilding the
        # entity is not going to be possible.
>       props_are_valid = reduce(operator.eq, (len(val) for val in properties.values()))
E       TypeError: reduce() of empty sequence with no initial value

/tmp/tox/test/pytest/lib/python3.7/site-packages/anom/properties.py:728: TypeError
```
In the tests i added you can see the different situations in which it goes wrong like in the stack trace.

Now my solution is a bit opinionated, but i propose to store None when not passed anything, when passed an empty list or when passed None. This fixes all the situations i added in the tests.

The only side effect being that when passing an empty list you might expect an empty list when you access that property, but you don't. However, before if you passed nothing you got an empty list instead, which also might not be expected (generally you would expect None). This also broke comparisons between an entity before and after putting, which is now also fixed. 

The best solution would obviously be to correctly store whatever we get passed, so you could look into that if you want (the line in the stacktrace is the big breaking point, so start looking there), but i couldn't figure out how. Therefore i think this at least better considering it just crashed before. 