### PR TITLE
feat: add Unicode property that stores strings without encoding them

### DIFF
--- a/anom/properties.py
+++ b/anom/properties.py
@@ -632,6 +632,47 @@ class Text(Encodable, Compressable, Property):
     _types = (str,)
 
 
+class Unicode(Property):
+    """A Property for string values that should be stored as unicode strings.
+
+    Parameters:
+      name(str, optional): The name of this property on the Datastore
+        entity.  Defaults to the name of this property on the model.
+      default(object, optional): The property's default value.
+      indexed(bool, optional): Whether or not this property should be
+        indexed.  Defaults to ``False``.
+      indexed_if(callable, optional): Whether or not this property
+        should be indexed when the callable returns ``True``.
+        Defaults to ``None``.
+      optional(bool, optional): Whether or not this property is
+        optional.  Defaults to ``False``.  Required but empty values
+        cause models to raise an exception before data is persisted.
+      repeated(bool, optional): Whether or not this property is
+        repeated.  Defaults to ``False``.  Optional repeated
+        properties default to an empty list.
+    """
+
+    _types = (str,)
+
+    def _validate_length(self, value):
+        if len(value.encode('utf-8')) > _max_indexed_length:
+            raise ValueError(
+                f"Unicode value is longer than the maximum allowed length "
+                f"({_max_indexed_length} bytes) for indexed properties. Set "
+                f"indexed to False if the value should not be indexed."
+            )
+
+    def validate(self, value):
+        value = super().validate(value)
+        if not self.indexed or value is None:
+            return value
+
+        if not self.repeated:
+            self._validate_length(value)
+
+        return value
+
+
 class Embed(EmbedLike):
     """A property for embedding entities inside other entities.
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -130,6 +130,10 @@ class ModelWithJsonProperty(Model):
     j = props.Json()
 
 
+class ModelWithUnicodeProperty(Model):
+    u = props.Unicode()
+
+
 class ModelWithCustomKind(Model):
     _kind = "CustomKind"
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -364,3 +364,28 @@ def test_repeated_keys_can_be_assigned_to_model(adapter):
     assert subscriber
     assert subscriber.tags[0].get() == tag1
     assert subscriber.tags[1].get() == tag2
+
+
+def test_models_with_unicode_properties_can_be_stored(adapter):
+    entity_1 = models.ModelWithUnicodeProperty()
+    entity_1.u = "テスト"
+
+    entity_1.put()
+
+    entity_2 = entity_1.key.get()
+    assert entity_2.u == "テスト"
+
+
+def test_unicode_properties_can_be_assigned_arbitrarily_long_values():
+    string = props.Unicode()
+    text = "♥" * 501  # Black Heart Suit (U+2665) is 3 bytes long
+    assert len(text.encode('utf-8')) == 1503
+    assert string.validate(text)
+
+
+def test_indexed_unicode_properties_cannot_be_assigned_values_longer_than_the_max():
+    string = props.Unicode(indexed=True)
+    text = "♥" * 501  # Black Heart Suit (U+2665) is 3 bytes long
+    assert len(text.encode('utf-8')) == 1503
+    with pytest.raises(ValueError):
+        string.validate(text)


### PR DESCRIPTION
As proposed in #12, this adds a new property named `Unicode` which stores string values as strings to the datastore, without encoding them when persisting to Datastore. 